### PR TITLE
fix: `x-search` component issues

### DIFF
--- a/src/Web/CommandPalette/register-palette.ts
+++ b/src/Web/CommandPalette/register-palette.ts
@@ -1,16 +1,16 @@
 import { useActiveElement, useMagicKeys, whenever } from '@vueuse/core'
-import { logicAnd } from '@vueuse/math'
-import { computed, type Ref, watchEffect } from 'vue'
+import { logicAnd, logicOr } from '@vueuse/math'
+import { computed, type Ref } from 'vue'
 
 interface Options {
 	value: Ref<boolean>
 }
 
 /**
- * Registers `/` and `Cmd+K` hotkeys, as well as a `toggleCommandPalette` function.
+ * Registers `/` and `Cmd+K`/`Ctrl+K` hotkeys, as well as a `toggleCommandPalette` function.
  */
 export function registerPalette(options: Options) {
-	const { Meta_K, Slash } = useMagicKeys({
+	const { Meta_K, Ctrl_K, Slash } = useMagicKeys({
 		target: document.body,
 		passive: false,
 		onEventFired(e) {
@@ -19,12 +19,16 @@ export function registerPalette(options: Options) {
 			}
 
 			if (e.key === '/' && e.type === 'keydown') {
-				e.preventDefault()
+        e.preventDefault()
 			}
 
-			if (e.key === 'k' && e.type === 'keydown' && e.metaKey) {
+			if (e.key === 'k' && e.type === 'keydown' && e.metaKey /* && OS is MacOS */) {
 				e.preventDefault()
-			}
+      }
+
+      if (e.key === 'k' && e.type === 'keydown' && e.ctrlKey /* && OS is not MacOS */) {
+        e.preventDefault()
+      }
 		},
 	})
 
@@ -39,9 +43,17 @@ export function registerPalette(options: Options) {
 		element.addEventListener('click', toggleCommandPalette)
 	})
 
-	const activeElement = useActiveElement()
-	const notUsingInput = computed(() => !['INPUT', 'TEXTAREA'].includes(activeElement.value?.tagName ?? ''))
+	const activeElement = useActiveElement({ triggerOnRemoval: true })
+  const notUsingInput = computed(() => !['INPUT', 'TEXTAREA'].includes(activeElement.value?.tagName ?? ''))
+  // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform#determining_the_modifier_key_for_the_users_platform
+  const isMacKbdLayout = navigator.platform.toLowerCase().startsWith('mac')
 
-	whenever(logicAnd(Meta_K, notUsingInput), () => options.value.value = !options.value.value)
+  whenever(
+    logicOr(
+      logicAnd(Meta_K, notUsingInput, isMacKbdLayout),
+      logicAnd(Ctrl_K, notUsingInput, !isMacKbdLayout)
+    ),
+    () => options.value.value = !options.value.value
+  )
 	whenever(logicAnd(Slash, notUsingInput), () => options.value.value = true)
 }

--- a/src/Web/x-search.view.php
+++ b/src/Web/x-search.view.php
@@ -3,7 +3,6 @@
     <x-icon name="tabler:search" class="size-4 shrink-0 text-(--ui-text-dimmed)"/>
     <span class="truncate">Search docs, blog...</span>
     <kbd class="ml-2 inline-flex items-center gap-0.5 rounded border border-(--ui-border) bg-(--ui-bg-muted) px-1.5 py-0.5 text-xs text-(--ui-text-dimmed) font-medium">
-        <x-icon name="tabler:command" class="size-3"/>
-        K
+        /
     </kbd>
 </button>


### PR DESCRIPTION
There are 2 problems with `x-search` component right now:

1. Focus isn't released on `command-palette` (from `src/Web/CommandPalette/command-palette.vue`) close with `esc` key
2. `Meta+k` doesn't work on non-MacOS platforms.

This PR fixes these problems